### PR TITLE
fix: register sidebarqa settings namespace after settings service is ready

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -278,8 +278,8 @@ export function apply(ctx: Context): void {
   // concurrent change (mirror of the settings seam's own guard).
   let configScope: SidebarqaSettingsScope<SidebarqaConfig> | undefined
   let configFace: ConfigFace | undefined
-  const settingsService = ctx.get('settings') as unknown as SidebarqaSettingsService | undefined
-  if (settingsService !== undefined) {
+  ctx.inject(['settings'], (sctx) => {
+    const settingsService = sctx.settings as unknown as SidebarqaSettingsService
     try {
       configScope = settingsService.register<SidebarqaConfig>(SIDEBARQA_SETTINGS_NS, SidebarqaPrefsSchema)
       const viewOf = (): { value?: unknown; revision?: number } => {
@@ -300,7 +300,7 @@ export function apply(ctx: Context): void {
     } catch (error) {
       console.warn('[dsh-sidebar-qa] settings registration failed; using defaults:', error)
     }
-  }
+  })
   const getConfig = (): SidebarqaConfig => {
     try {
       return configScope?.get() ?? SIDEBARQA_DEFAULTS


### PR DESCRIPTION
## Problem

The qachat settings panel failed to save with:

\\\
the settings service is not mounted in this deployment
\\\

The host half used \ctx.get('settings')\ during \pply()\, which can run before the optional settings service has finished initializing. Even when \@deepseek-ai/dsh-settings-file\ is mounted, \configFace\ stays undefined and \/sidebarqa/api/config.update\ returns 503.

## Fix

Use \ctx.inject(['settings'])\ so the \sidebarqa\ namespace is registered only after the settings service is actually available, matching the pattern used by dsh-better-sidebar.

## Verification

- \pnpm typecheck\ passes
- \pnpm build\ passes
- After hot reload, \/sidebarqa/api/config.get\ now returns a \evision\, and \/sidebarqa/api/config.update\ returns 200