### PR TITLE
feat: 跨插件 seam——openTab meta.quote 预填追问引文

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ dsh-sidebar-qa (bundle: dsh.bundle + package.json#dsh.client)
     └── api.ts              /sidebarqa/api fetch 封装 + 当前模型读取
 ```
 
+### 跨插件 seam（meta.quote）
+
+外部插件可以打开追问 tab 并**预填引文**（不经本插件的划选浮层）：通过 better-sidebar 的 `openTab` seed 携带 `meta`：
+
+```ts
+ctx.betterSidebar.openTab(
+  { type: 'dsh-sidebar-qa:ask', meta: { quote: { text: '选中的内容', role: 'user' } } },
+)
+```
+
+面板优先显示 `meta.quote`（形状校验：`text` 为非空字符串；可选透传 `role` / `messageId`），回退到本插件浮层的 pending 引文；用户输入问题发送后引文即被消费（`updateTab` 清除），刷新/再次聚焦不会复现旧引文。`<quoted_context>` 的 `source` 标签沿用 `agent-history`。
+
 ### 关键数据流
 
 ```

--- a/src/client/AskPanel.tsx
+++ b/src/client/AskPanel.tsx
@@ -12,6 +12,7 @@ import type { Context, SidebarqaTabComponentProps } from '../context-types.ts'
 import { transcriptOf, type TranscriptMessage } from './answer.ts'
 import { parseUserMessage } from './injection.ts'
 import { askFollowUp, sendFollowUp, titleSideSessionOnce } from './orchestrate.ts'
+import { resolveMetaQuote, consumeMetaQuote } from './meta-quote.ts'
 import type { SidebarqaStore } from './store.ts'
 import css from './ask-panel.module.css'
 
@@ -32,7 +33,11 @@ export function AskPanel(props: AskPanelProps) {
     (cb: () => void) => store.subscribe(cb),
     () => store.getSnapshot(),
   )
-  const pendingQuote = snapshot.pendingBySession[sessionId] ?? null
+  // Cross-plugin seam: a quote handed over through `openTab({ meta: { quote } })`
+  // (e.g. dsh-sidebar-preview-select's preview selection) takes precedence over
+  // the store's pending quote; the store path stays the popover's channel.
+  const metaQuote = resolveMetaQuote(props.tab.meta)
+  const pendingQuote = metaQuote ?? snapshot.pendingBySession[sessionId] ?? null
   const children = snapshot.parentToChildren[sessionId] ?? []
 
   const sessionList = useSyncExternalStore(
@@ -124,6 +129,11 @@ export function AskPanel(props: AskPanelProps) {
         )
         setActiveChildId(result.sideSessionId)
         store.setPendingQuote(sessionId, null)
+        // Consume a meta-carried quote after it was sent, so refocusing the tab
+        // (or a page reload, where the meta persists) never resurfaces it.
+        if (metaQuote !== null) {
+          ctx.betterSidebar.updateTab(props.tab.id, { meta: consumeMetaQuote(props.tab.meta) })
+        }
         setPhase('answering')
       } else {
         await sendFollowUp(ctx, activeChildId, q)

--- a/src/client/AskPanel.tsx
+++ b/src/client/AskPanel.tsx
@@ -12,7 +12,7 @@ import type { Context, SidebarqaTabComponentProps } from '../context-types.ts'
 import { transcriptOf, type TranscriptMessage } from './answer.ts'
 import { parseUserMessage } from './injection.ts'
 import { askFollowUp, sendFollowUp, titleSideSessionOnce } from './orchestrate.ts'
-import { resolveMetaQuote, consumeMetaQuote } from './meta-quote.ts'
+import { resolveMetaQuote, consumeMetaQuote, resolveAskMode } from './meta-quote.ts'
 import type { SidebarqaStore } from './store.ts'
 import css from './ask-panel.module.css'
 
@@ -131,9 +131,7 @@ export function AskPanel(props: AskPanelProps) {
         store.setPendingQuote(sessionId, null)
         // Consume a meta-carried quote after it was sent, so refocusing the tab
         // (or a page reload, where the meta persists) never resurfaces it.
-        if (metaQuote !== null) {
-          ctx.betterSidebar.updateTab(props.tab.id, { meta: consumeMetaQuote(props.tab.meta) })
-        }
+        consumeMeta()
         setPhase('answering')
       } else {
         await sendFollowUp(ctx, activeChildId, q)
@@ -147,7 +145,29 @@ export function AskPanel(props: AskPanelProps) {
   }
 
   const busy = phase === 'asking'
-  const mode = pendingQuote !== null ? 'start' : activeChildId !== null ? 'conversation' : 'empty'
+  // A parked quote only owns the view while no follow-up is selected: the
+  // switcher can always return to an existing conversation, and the 新追问
+  // button returns to the parked quote (see resolveAskMode).
+  const mode = resolveAskMode(pendingQuote !== null, activeChildId)
+
+  // Consume the meta-carried quote channel once (send or cancel both count).
+  const consumeMeta = (): void => {
+    if (metaQuote !== null) {
+      ctx.betterSidebar.updateTab(props.tab.id, { meta: consumeMetaQuote(props.tab.meta) })
+    }
+  }
+
+  // Cancel a parked quote: clear both channels and return to the latest
+  // follow-up when one exists, else the empty hint.
+  const clearQuote = (): void => {
+    store.setPendingQuote(sessionId, null)
+    consumeMeta()
+    const list = store.childrenOf(sessionId)
+    setActiveChildId(list.length > 0 ? (list[list.length - 1] ?? null) : null)
+    setMessages([])
+    setPhase('idle')
+    setError(null)
+  }
 
   return (
     <div className={css.root}>
@@ -183,7 +203,10 @@ export function AskPanel(props: AskPanelProps) {
             {pendingQuote !== null && pendingQuote.text !== ''
               ? (
                 <div className={css.quoteChip}>
-                  <div className={css.quoteChipHead}>引文</div>
+                  <div className={css.quoteChipHead}>
+                    引文
+                    <button type="button" className={css.quoteCancel} onClick={clearQuote}>取消</button>
+                  </div>
                   <div className={css.quoteChipText}>{pendingQuote.text}</div>
                 </div>
               )

--- a/src/client/ask-panel.module.css
+++ b/src/client/ask-panel.module.css
@@ -128,10 +128,26 @@
 }
 
 .quoteChipHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 5px 10px;
   background: var(--dsw-alias-bg-layer-3);
   font-size: 12px;
   color: var(--dsw-alias-label-tertiary);
+}
+
+.quoteCancel {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 12px;
+  color: var(--dsw-alias-label-tertiary);
+  cursor: pointer;
+}
+
+.quoteCancel:hover {
+  color: var(--dsw-alias-label-primary);
 }
 
 .quoteChipText {

--- a/src/client/meta-quote.ts
+++ b/src/client/meta-quote.ts
@@ -43,3 +43,17 @@ export function consumeMetaQuote(meta: unknown): unknown {
   const { quote: _quote, ...rest } = record
   return rest
 }
+
+/**
+ * The panel's view mode. A pending quote only owns the view while no
+ * follow-up is selected: picking an existing child in the switcher returns to
+ * that conversation (the quote stays parked for the 新追问 button), and
+ * cancelling the quote without children falls back to the empty hint.
+ * @param hasQuote - whether a pending quote (store or meta) is present.
+ * @param activeChildId - the selected follow-up session, or null.
+ * @returns the view mode.
+ */
+export function resolveAskMode(hasQuote: boolean, activeChildId: string | null): 'start' | 'conversation' | 'empty' {
+  if (activeChildId !== null) return 'conversation'
+  return hasQuote ? 'start' : 'empty'
+}

--- a/src/client/meta-quote.ts
+++ b/src/client/meta-quote.ts
@@ -1,0 +1,45 @@
+/**
+ * Cross-plugin seam: a pending quote carried on a tab's open seed
+ * (`openTab({ type: 'dsh-sidebar-qa:ask', meta: { quote } })`). External
+ * plugins (e.g. dsh-sidebar-preview-select) open the ask tab with a quote
+ * they captured themselves — a preview selection, a file excerpt — instead of
+ * going through this plugin's own selection popover. The tab meta is the only
+ * channel that reaches the panel component across plugin boundaries, because
+ * the store instance (and its pendingBySession) is apply-private state.
+ */
+import type { PendingQuote } from './store.ts'
+
+/**
+ * Read a quote off a tab's `meta` slot, validating the wire shape.
+ * `meta` is JSON-serializable unknown data set by any caller, so the shape is
+ * checked field by field; anything unexpected yields null and the panel falls
+ * back to the store's pending quote (or no quote).
+ * @param meta - the tab's `meta` value (may be absent or anything).
+ * @returns the quote, or null when absent or not a valid quote.
+ */
+export function resolveMetaQuote(meta: unknown): PendingQuote | null {
+  if (meta === null || meta === undefined || typeof meta !== 'object') return null
+  const record = meta as Record<string, unknown>
+  const text = record.quote
+  if (typeof text !== 'string' || text.trim() === '') return null
+  const quote: PendingQuote = { text }
+  if (typeof record.messageId === 'string') quote.messageId = record.messageId
+  if (typeof record.role === 'string') quote.role = record.role
+  return quote
+}
+
+/**
+ * Strip a consumed quote off a tab's `meta` value, keeping any other keys.
+ * The panel calls this after the quote was sent, so a later focus of the same
+ * tab (or a page reload, where the meta persists) does not resurface the
+ * stale quote.
+ * @param meta - the tab's current `meta` value.
+ * @returns a new meta object without `quote`, or undefined when meta was absent.
+ */
+export function consumeMetaQuote(meta: unknown): unknown {
+  if (meta === null || meta === undefined || typeof meta !== 'object') return meta
+  const record = meta as Record<string, unknown>
+  if (!Object.hasOwn(record, 'quote')) return meta
+  const { quote: _quote, ...rest } = record
+  return rest
+}

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -160,7 +160,7 @@ export interface SidebarqaTabDescriptor {
 export interface SidebarqaTabComponentProps {
   ctx: Context
   scope: { sessionId: string; cwd?: string }
-  tab: { id: string; type: string; title: string; path?: string; diff?: unknown }
+  tab: { id: string; type: string; title: string; path?: string; diff?: unknown; meta?: unknown }
   visible: boolean
 }
 
@@ -171,12 +171,19 @@ export interface SidebarqaBetterSidebarService {
    * Open (or focus) a tab. `scope` (v0.12.0+ targeted open) names the session
    * whose sidebar state receives the open — the tab lands there even when that
    * session is not the one on screen, and the UI's active session is not
-   * switched. Omitted scope targets the active session.
+   * switched. Omitted scope targets the active session. `meta` (v0.13.0+
+   * better-sidebar) carries JSON-serializable custom state onto the tab —
+   * external plugins use `meta.quote` to hand this panel a pending quote.
    */
   openTab(
-    seed: { type: string; title?: string; id?: string; path?: string; url?: string },
+    seed: { type: string; title?: string; id?: string; path?: string; url?: string; meta?: unknown },
     scope?: { sessionId: string; cwd?: string },
   ): void
+  /**
+   * Update one open tab's display fields (better-sidebar v0.12.0+). Unknown
+   * tab ids are a no-op. Used to consume a `meta.quote` after it was sent.
+   */
+  updateTab(tabId: string, patch: { title?: string; path?: string; meta?: unknown }): void
 }
 
 /** One session list row the client reads (display title + lineage + cwd + activity). */

--- a/tests/meta-quote.spec.ts
+++ b/tests/meta-quote.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMetaQuote, consumeMetaQuote } from '../src/client/meta-quote.ts'
+
+describe('resolveMetaQuote', () => {
+  it('reads a plain text quote off the meta slot', () => {
+    expect(resolveMetaQuote({ quote: '选中的一段内容' })).toEqual({ text: '选中的一段内容' })
+  })
+
+  it('passes optional fields through when they are strings', () => {
+    expect(resolveMetaQuote({ quote: 'text', role: 'user', messageId: 'm1' }))
+      .toEqual({ text: 'text', role: 'user', messageId: 'm1' })
+  })
+
+  it('rejects absent, non-object, or blank meta', () => {
+    expect(resolveMetaQuote(undefined)).toBeNull()
+    expect(resolveMetaQuote(null)).toBeNull()
+    expect(resolveMetaQuote('quote')).toBeNull()
+    expect(resolveMetaQuote(42)).toBeNull()
+    expect(resolveMetaQuote({})).toBeNull()
+    expect(resolveMetaQuote({ quote: '' })).toBeNull()
+    expect(resolveMetaQuote({ quote: '   ' })).toBeNull()
+    expect(resolveMetaQuote({ quote: 42 })).toBeNull()
+  })
+
+  it('ignores non-string optional fields instead of passing them', () => {
+    expect(resolveMetaQuote({ quote: 'text', role: 42, messageId: null }))
+      .toEqual({ text: 'text' })
+  })
+})
+
+describe('consumeMetaQuote', () => {
+  it('strips the quote key and keeps sibling keys', () => {
+    expect(consumeMetaQuote({ quote: 'text', other: 1 })).toEqual({ other: 1 })
+  })
+
+  it('leaves meta without a quote untouched (same reference)', () => {
+    const meta = { other: 1 }
+    expect(consumeMetaQuote(meta)).toBe(meta)
+  })
+
+  it('passes absent or non-object meta through', () => {
+    expect(consumeMetaQuote(undefined)).toBeUndefined()
+    expect(consumeMetaQuote(null)).toBeNull()
+    expect(consumeMetaQuote('x')).toBe('x')
+  })
+})

--- a/tests/meta-quote.spec.ts
+++ b/tests/meta-quote.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveMetaQuote, consumeMetaQuote } from '../src/client/meta-quote.ts'
+import { resolveMetaQuote, consumeMetaQuote, resolveAskMode } from '../src/client/meta-quote.ts'
 
 describe('resolveMetaQuote', () => {
   it('reads a plain text quote off the meta slot', () => {
@@ -42,5 +42,23 @@ describe('consumeMetaQuote', () => {
     expect(consumeMetaQuote(undefined)).toBeUndefined()
     expect(consumeMetaQuote(null)).toBeNull()
     expect(consumeMetaQuote('x')).toBe('x')
+  })
+})
+
+describe('resolveAskMode', () => {
+  it('starts a new follow-up when a quote is parked and nothing is selected', () => {
+    expect(resolveAskMode(true, null)).toBe('start')
+  })
+
+  it('returns to the selected conversation even while a quote is parked (switcher regression)', () => {
+    expect(resolveAskMode(true, 'child-a')).toBe('conversation')
+  })
+
+  it('shows the empty hint without a quote and without a selection', () => {
+    expect(resolveAskMode(false, null)).toBe('empty')
+  })
+
+  it('stays in conversation without a quote once a child is selected', () => {
+    expect(resolveAskMode(false, 'child-a')).toBe('conversation')
   })
 })


### PR DESCRIPTION
## 背景

dsh-sidebar-preview-select（一个新插件：better-sidebar 预览面板内划选内容 → 发送到会话）计划提供「发送到追问」双按钮协同本插件。但本插件的 pending 引文存在 apply 私有内存 store（`pendingBySession`）里，外部插件无法把引文送进追问面板。

## 方案

利用 better-sidebar 已有的 `openTab` seed `meta` 通道（v0.13.0+ 支持 `meta` 自定义状态）作为跨插件 seam：

```ts
ctx.betterSidebar.openTab(
  { type: 'dsh-sidebar-qa:ask', meta: { quote: { text: '选中的内容', role: 'user' } } },
)
```

## 改动

### feat: 跨插件 seam（7892425）

- `src/client/meta-quote.ts`（新）：`resolveMetaQuote(meta)` 形状校验（`text` 非空字符串，可选 `role`/`messageId` 透传，其它字段忽略）；`consumeMetaQuote(meta)` 消费后剥离 `quote` 键保留兄弟键；
- `src/client/AskPanel.tsx`：引文优先取 `tab.meta.quote`，fallback 现有 store pending；发送成功后 `updateTab` 消费清除（刷新/再次聚焦不复活旧引文）；
- `src/context-types.ts`：镜像类型补齐 `tab.meta`、`openTab` seed `meta`、`updateTab`；
- `tests/meta-quote.spec.ts`（新）；README 补 seam 说明。

### fix: 追问面板引文状态（6264ee0）

修复既有回归（与 seam 无关但同文件，一并提交）：选取新内容 B 而未提问时，`mode` 被 `pendingQuote` 锁死在 start——**tab 切换器无法回到已发起的追问 A，且 B 没有取消入口**。

- `mode` 推导抽为 `resolveAskMode` 纯函数：引文只在未选中子会话时持有视图；选中 A 后回到 conversation（引文保留，「新追问」按钮可回到 B）；
- 引文 chip 增加「取消」按钮（`clearQuote`：清 store pending + 消费 meta.quote + 回到最新子会话/空态）；
- 新增 4 个 `resolveAskMode` 回归用例。

## 兼容性

- 纯增量：不传 `meta` 的现有调用路径行为完全不变（fallback 到 store pending）；
- 测试：全量 `vitest run` 98 用例通过；`tsc --noEmit` 通过。

## 支持计划

dsh-sidebar-preview-select（Max-Null 账号，开发中）将在本 PR 合并发布后，浮层提供「发送到追问」按钮（检测 `dsh-sidebar-qa:ask` tab 已注册才显示），点击即以 `meta.quote` 打开追问面板带引文，问题在面板下部输入框输入——与本插件原生交互一致。