### PR TITLE
feat: 自动归档已完成的追问会话（auto-archive finished follow-ups）

### DIFF
--- a/src/client/AskPanel.tsx
+++ b/src/client/AskPanel.tsx
@@ -12,7 +12,7 @@ import type { Context, SidebarqaHistoryEntry, SidebarqaModelSelection, Sidebarqa
 import type { SidebarqaHistoryStrategy } from '../config.ts'
 import { lastEndSeedIndex, transcriptRowsOf, type TranscriptRow } from './answer.ts'
 import { parseUserMessage } from './injection.ts'
-import { askFollowUp, sendFollowUp, titleSideSessionOnce } from './orchestrate.ts'
+import { askFollowUp, archiveSideSession, sendFollowUp, titleSideSessionOnce } from './orchestrate.ts'
 import { sidebarqaApi } from './api.ts'
 import { StrategySelect } from './StrategySelect.tsx'
 import { ModelSelect } from './ModelSelect.tsx'
@@ -60,6 +60,7 @@ export function AskPanel(props: AskPanelProps) {
   // compressed/trim children; inherit children keep the parent's model anyway.
   const [pendingModel, setPendingModel] = useState<SidebarqaModelSelection | null>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
+  const prevVisibleRef = useRef(visible)
 
   const activeRunning = activeChildId !== null && sessionList.byId[activeChildId]?.running === true
   // The composer's model seat and context meter bind to the session the ask is
@@ -264,6 +265,20 @@ export function AskPanel(props: AskPanelProps) {
   useEffect(() => {
     if (!activeRunning) setPhase(prev => (prev === 'answering' ? 'idle' : prev))
   }, [activeRunning])
+
+  // Auto-archive: when the user closes the 追问 panel or switches away from it
+  // (visible → false), archive the active follow-up session so it no longer
+  // clutters the left conversation list — provided it has finished answering
+  // (not running) and the feature is enabled. The record is preserved and stays
+  // browsable in the 追问记录 tree; it can be restored via the row menu.
+  useEffect(() => {
+    const leaving = prevVisibleRef.current && !visible
+    prevVisibleRef.current = visible
+    if (!leaving) return
+    if (activeChildId === null) return
+    if (sessionList.byId[activeChildId]?.running === true) return
+    void archiveSideSession(ctx, activeChildId)
+  }, [visible, activeChildId, ctx, sessionList])
 
   const submit = async (): Promise<void> => {
     const q = question.trim()

--- a/src/client/ConfigPanel.tsx
+++ b/src/client/ConfigPanel.tsx
@@ -33,6 +33,7 @@ function FieldRow(props: {
   const { field, value, onCommit } = props
   const [draft, setDraft] = useState(value)
   const number = field.type === 'number'
+  const bool = field.type === 'boolean'
   const commit = (raw: string): void => { setDraft(onCommit(raw)) }
   return (
     <div className={css.row}>
@@ -40,7 +41,17 @@ function FieldRow(props: {
         <span className={css.title}>{field.label}</span>
         {field.desc !== undefined && field.desc !== '' && <span className={css.desc}>{field.desc}</span>}
       </span>
-      {field.type === 'select' ? (
+      {bool ? (
+        <label className={css.boolLabel}>
+          <input
+            type="checkbox"
+            checked={draft === 'true'}
+            aria-label={field.label}
+            onChange={(event) => { commit(event.currentTarget.checked ? 'true' : 'false') }}
+          />
+          <span>{draft === 'true' ? '开' : '关'}</span>
+        </label>
+      ) : field.type === 'select' ? (
         <select
           className={css.select}
           value={draft}
@@ -136,6 +147,11 @@ export function ConfigPanel(): ReactElement {
       if (clamped === null) return fallback
       commit({ [field.key]: clamped })
       return String(clamped)
+    }
+    if (field.type === 'boolean') {
+      const next = raw === 'true'
+      commit({ [field.key]: next })
+      return String(next)
     }
     commit({ [field.key]: raw })
     return raw

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -69,6 +69,7 @@ export interface SidebarqaConfigView {
   answerModel: string
   answerReasoningEffort: string
   titleBudgetTokens: number
+  autoArchiveAfterLeave: boolean
 }
 
 /** The config namespace envelope (value + revision for revision-guarded writes). */

--- a/src/client/config-fields.ts
+++ b/src/client/config-fields.ts
@@ -10,7 +10,7 @@ import type { SidebarqaConfigView } from './api.ts'
 export type ConfigFieldKey = keyof SidebarqaConfigView
 
 /** One config panel row control type. */
-export type ConfigFieldType = 'text' | 'number' | 'select'
+export type ConfigFieldType = 'text' | 'number' | 'select' | 'boolean'
 
 /** One choice of a select row. */
 export interface ConfigFieldOption {
@@ -64,6 +64,7 @@ export const CONFIG_FIELDS: readonly ConfigField[] = [
   { key: 'summarizeProvider', label: '摘要模型渠道', type: 'text', placeholder: '留空 = 继承被追问会话', desc: '快速无思考摘要/标题模型的 provider' },
   { key: 'summarizeModel', label: '摘要模型', type: 'text', desc: '快速无思考模型的 id' },
   { key: 'summarizeReasoningEffort', label: '摘要思考模式', type: 'select', options: REASONING_EFFORT_OPTIONS, desc: 'Off 关闭思考；High / Max 逐级增强推理' },
+  { key: 'autoArchiveAfterLeave', label: '自动归档追问会话', type: 'boolean', desc: '关闭/切走追问面板后，自动把已完成的追问会话从主会话列表隐藏（记录仍在「追问记录」）；可在侧边栏恢复' },
 ]
 
 /**

--- a/src/client/config-panel.module.css
+++ b/src/client/config-panel.module.css
@@ -75,6 +75,23 @@
   width: 200px;
 }
 
+.boolLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+  font-size: 13px;
+  color: var(--dsw-alias-label-primary);
+  cursor: pointer;
+}
+
+.boolLabel input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--dsw-alias-button-primary-fill);
+}
+
 .textInput:focus,
 .numberInput:focus,
 .select:focus {

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -18,6 +18,7 @@ import { HistoryPanel } from './HistoryPanel.tsx'
 import { SelectionPopover } from './SelectionPopover.tsx'
 import { createSelectionController } from './selection.ts'
 import { createSidebarqaStore } from './store.ts'
+import { sidebarqaApi } from './api.ts'
 import type { PendingQuote } from './store.ts'
 
 /** Services required before mounting (provided by the client runtime; betterSidebar by dsh-better-sidebar). */
@@ -84,4 +85,37 @@ export function apply(ctx: Context): void {
 
   // Release the selection listeners on disposal.
   ctx.effect(() => () => { selectionController.dispose() }, 'dsh-sidebar-qa: selection listeners')
+
+  // One-time cleanup of pre-existing finished follow-ups: on activation, archive
+  // every previously-created 追问 session that has already finished answering
+  // (not running) and is not the currently-open session, so historical follow-ups
+  // no longer clutter the left conversation list. The records stay browsable in
+  // the 追问记录 tree. Honors the autoArchiveAfterLeave config, is idempotent
+  // (archiving an already-archived session is a no-op), and never touches running
+  // sessions. Best-effort: failures are logged, never thrown.
+  ctx.effect(() => {
+    let disposed = false
+    void (async () => {
+      try {
+        const config = await sidebarqaApi.config()
+        if (disposed || !config.autoArchiveAfterLeave) return
+        const snapshot = store.getSnapshot()
+        const sessionList = ctx.sessions.list.getSnapshot()
+        const current = sessionList.current
+        for (const childIds of Object.values(snapshot.parentToChildren)) {
+          for (const id of childIds) {
+            if (disposed) return
+            const summary = sessionList.byId[id]
+            if (summary === undefined) continue
+            if (summary.running === true) continue
+            if (id === current) continue
+            try { await ctx.workspaces.archiveSession(id) } catch (error) { console.warn('[dsh-sidebar-qa] initial auto-archive failed:', error) }
+          }
+        }
+      } catch {
+        // config fetch failed — skip the one-time cleanup.
+      }
+    })()
+    return () => { disposed = true }
+  }, 'dsh-sidebar-qa: initial cleanup of finished follow-ups')
 }

--- a/src/client/orchestrate.ts
+++ b/src/client/orchestrate.ts
@@ -110,6 +110,7 @@ async function loadConfig(ctx: Context): Promise<SidebarqaConfigView> {
       answerModel: 'deepseek-v4-flash',
       answerReasoningEffort: 'off',
       titleBudgetTokens: 64,
+      autoArchiveAfterLeave: true,
     }
   }
 }
@@ -302,5 +303,23 @@ export async function titleSideSessionOnce(
     await tryRename(ctx, sideSessionId, followUpTitle(result.title))
   } catch {
     // Retitle is best-effort: the placeholder title remains.
+  }
+}
+
+/**
+ * Archive a finished follow-up session when the user leaves the 追问 panel
+ * (auto-archive). Honors the `autoArchiveAfterLeave` config: when disabled,
+ * this is a no-op. Archiving hides the session from the left-side conversation
+ * list (native DSH archive) but preserves its records — it stays browsable in
+ * the 追问记录 tree and can be restored via the sidebar row menu.
+ * Best-effort: failures are logged, never thrown back to the panel.
+ */
+export async function archiveSideSession(ctx: Context, sideSessionId: string): Promise<void> {
+  try {
+    const config = await loadConfig(ctx)
+    if (!config.autoArchiveAfterLeave) return
+    await ctx.workspaces.archiveSession(sideSessionId)
+  } catch (error) {
+    console.warn('[dsh-sidebar-qa] auto-archive failed:', error)
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,16 @@ export interface SidebarqaConfig {
   // ── Title (post-answer retitle, reuses the summarize model route) ─────────
   /** Output-token cap for the post-answer title generation. */
   titleBudgetTokens: number
+
+  // ── Auto-archive (hide finished follow-ups from the main sidebar list) ─────
+  /**
+   * When true, a follow-up session is archived (hidden from the left-side
+   * conversation list) as soon as the user closes the 追问 panel or switches
+   * away from it — provided that session has already finished answering
+   * (not running). The session record is preserved and remains browsable in
+   * the 追问记录 tree; it can be restored via the sidebar row menu.
+   */
+  autoArchiveAfterLeave: boolean
 }
 
 /** Schema-backed defaults (also used when the settings service is absent). */
@@ -70,6 +80,7 @@ export const SIDEBARQA_DEFAULTS: SidebarqaConfig = {
   answerModel: 'deepseek-v4-flash',
   answerReasoningEffort: 'off',
   titleBudgetTokens: 64,
+  autoArchiveAfterLeave: true,
 }
 
 /** Schemastery schema for the `sidebarqa` settings namespace. */
@@ -86,4 +97,5 @@ export const SidebarqaPrefsSchema = z.object({
   answerModel: z.string().default(SIDEBARQA_DEFAULTS.answerModel),
   answerReasoningEffort: z.union(['off', 'high', 'max']).default(SIDEBARQA_DEFAULTS.answerReasoningEffort),
   titleBudgetTokens: z.number().step(1).min(16).max(256).default(SIDEBARQA_DEFAULTS.titleBudgetTokens),
+  autoArchiveAfterLeave: z.boolean().default(SIDEBARQA_DEFAULTS.autoArchiveAfterLeave),
 })

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -379,12 +379,19 @@ export interface SidebarqaWorkspaceListSnapshot {
   items: SidebarqaWorkspaceView[]
 }
 
-/** The client workspaces service face (only the list feed is needed). */
+/** The client workspaces service face. */
 export interface SidebarqaWorkspacesService {
   list: {
     getSnapshot(): SidebarqaWorkspaceListSnapshot
     subscribe(fn: () => void): () => void
   }
+  /**
+   * Archive a session into the registry-global archive set. Archived sessions
+   * are hidden from the left-side conversation list (grouping / flat list /
+   * search) but their records are preserved; unarchive is available via the
+   * sidebar row menu. Mirror of the runtime `IWorkspaces.archiveSession`.
+   */
+  archiveSession(sessionId: string): Promise<void>
 }
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# 自动归档追问会话（auto-archive finished follow-ups）

## 关联需求
dsh-sidebar-qa 每次划选提问都会真实创建一个独立的 `❓追问·` 会话，这些会话累积在左侧会话列表里，占据大量"对话格子"，尤其在频繁提问后很难受。

## 功能说明
新增一个默认开启的 **「自动归档」** 开关（配置项 `autoArchiveAfterLeave`，默认 `true`，可在 DSH 设置 → 侧边卡片 → 追问 → 功能配置 里关闭）：

- **新追问**：当用户**关闭追问面板或切到其它标签**时，若当前追问会话**已完成回答（不在运行中）**，自动将其**归档**——从左侧主会话列表隐藏，但记录完整保留，仍可在「追问记录」树里按主会话分组查看、跳转和在侧边栏恢复。
- **存量追问**：插件激活时，会自动把**之前已创建且已完成的旧追问会话**一次性归档，立刻清空主列表（幂等、不碰运行中的会话、不碰当前打开的会话）。

## 实现说明
复用 DSH 原生 `ctx.workspaces.archiveSession(sessionId)`（IWorkspaces 契约）：归档即把会话从左侧列表隐藏（grouping / flat / search 均排除），记录保留、可恢复。归档时机满足「切走/关闭面板才归档」的保守语义，且进行中的回答不会被中断。

## 改动内容
- `src/config.ts`：新增 `autoArchiveAfterLeave` 配置项（默认 `true`，schema 与 defaults）。
- `src/context-types.ts`：为 client `workspaces` 服务类型补上 `archiveSession`。
- `src/client/orchestrate.ts`：新增 `archiveSideSession()`（读取配置后调用原生归档）。
- `src/client/AskPanel.tsx`：追问面板由可见→隐藏时自动归档当前已完成的追问会话。
- `src/client/index.tsx`：激活时对存量已完成追问做一次性归档清理。
- `src/client/api.ts`：`SidebarqaConfigView` 补 `autoArchiveAfterLeave`。
- `src/client/config-fields.ts` / `ConfigPanel.tsx` / `config-panel.module.css`：配置面板新增布尔（checkbox）字段渲染与「自动归档追问会话」开关项。

## 测试
- `pnpm typecheck` 通过；`pnpm build`（tsdown）通过。
- 手动验证：新建追问 → 关闭面板 → 该会话从主列表消失且仍在「追问记录」可查；存量追问首次加载被自动归档。

## 兼容
默认开启，关闭开关后行为与旧版本一致（不归档）。归档操作幂等，不会删除任何会话数据。
