### PR TITLE
feat: 回答/摘要模型渠道与模型改为运行时模型目录下拉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本项目的版本遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)，日志格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [Unreleased]
+
+### Changed
+
+- **回答/摘要的模型渠道与模型均改为下拉选择**：功能配置面板中「回答模型渠道 / 回答模型 / 摘要模型渠道 / 摘要模型」四行从自由文本输入改为下拉框，选项来自运行时模型目录——渠道列表只列当前部署**已配置/已启用（有已注册 adapter）**的 channel（host `ctx.llm.listProviders()`，与 DSH 本身正在用的一致，未配置的 dormant 渠道不出现），模型列表随所选渠道联动（`ctx.llm.listModels(provider)`），经新增的 `/sidebarqa/api/catalog` 路由下发；切换渠道时自动锚定新渠道的第一个模型（原模型仍被该渠道服务则保留）。摘要渠道额外提供「继承被追问会话」空值项（对应原默认 `''`），其模型下拉在继承态展示全部渠道模型的并集。已保存值不在目录中时仍保留在选项中。host + client 半均有改动：需重启 `dsh web` 并硬刷新浏览器。
+
 ## [0.3.1] - 2026-08-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ dsh plugin --profile web add <本仓库路径>
 
 ## 配置
 
-配置走 DSH 设置服务 `sidebarqa` 命名空间（settings.yaml 或设置页）。**Web 界面入口**：DSH 设置 → 侧边卡片 → 「追问」卡片右上角的齿轮「功能配置」弹窗（由 dsh-better-sidebar v0.12+ 的 `settings.render` 提供），可逐项编辑下表字段——文本行 blur/Enter 提交，数字行按区间钳制，写入经 `/sidebarqa/api/config.update` 带 revision 乐观锁（多窗口冲突时提示重试）。
+配置走 DSH 设置服务 `sidebarqa` 命名空间（settings.yaml 或设置页）。**Web 界面入口**：DSH 设置 → 侧边卡片 → 「追问」卡片右上角的齿轮「功能配置」弹窗（由 dsh-better-sidebar v0.12+ 的 `settings.render` 提供），可逐项编辑下表字段——文本行 blur/Enter 提交，数字行按区间钳制，写入经 `/sidebarqa/api/config.update` 带 revision 乐观锁（多窗口冲突时提示重试）。**回答/摘要的模型渠道与模型**四行均为下拉，选项来自运行时模型目录（host `ctx.llm.listProviders()` + `listModels()`，经 `/sidebarqa/api/catalog` 下发）：渠道列表 = 当前部署**已配置/已启用（有已注册 adapter）**的 channel——与 DSH 本身正在用的一致，未配置的 dormant 渠道不出现（摘要渠道额外提供「继承被追问会话」空值项）；模型列表随所选渠道联动（切换渠道时自动锚定新渠道的第一个模型，若原模型仍在其中则保留；摘要模型在「继承」渠道下展示全部渠道的模型并集）。已保存值不在目录中时仍保留在选项里，避免已存路由显示为空。
 
 | 键 | 默认 | 说明 |
 |---|---|---|
 | `historyStrategy` | `compressed` | 默认上下文策略：`inherit` 全量继承（fork+缓存命中）/ `compressed` 压缩 / `trim` 机械裁切（面板内可逐次切换） |
 | `trimWindowMessages` | `10` | 机械裁切模式保留的最近消息条数（1–256） |
-| `summarizeProvider` | `''` | 摘要快速模型渠道；空 = 继承被追问会话的 provider |
-| `summarizeModel` | `deepseek-v4-flash` | 摘要快速无思考模型 |
+| `summarizeProvider` | `''` | 摘要快速模型渠道；空 = 继承被追问会话的 provider（下拉，含「继承」项） |
+| `summarizeModel` | `deepseek-v4-flash` | 摘要快速无思考模型（下拉，随所选渠道联动） |
 | `summarizeReasoningEffort` | `off` | 摘要思考模式（`off`/`high`/`max` 三档下拉） |
-| `answerProvider` | `deepseek-official` | 子对话回答模型渠道 |
-| `answerModel` | `deepseek-v4-flash` | 子对话回答模型 |
+| `answerProvider` | `deepseek-official` | 子对话回答模型渠道（下拉，来自运行时模型目录） |
+| `answerModel` | `deepseek-v4-flash` | 子对话回答模型（下拉，随所选渠道联动） |
 | `answerReasoningEffort` | `off` | 子对话思考模式（`off`/`high`/`max` 三档下拉） |
 
 > 面板只展示上述 8 项常用设置；压缩/标题的内部调参键（`summarizeBudgetTokens`、`recentWindowMessages`、`backgroundWindowMessages`、`titleBudgetTokens`）不在面板暴露，仍可在 `settings.yaml` 的 `sidebarqa` 命名空间里配置。
@@ -104,6 +104,8 @@ dsh-sidebar-qa (bundle: dsh.bundle + package.json#dsh.client)
     ├── ensure-panel.ts      面板收起自愈：展开判定 + 经 SidebarStore 展开（纯函数，可测）
     ├── tab-activation.ts    onActivate 激活桥：收起后重新激活 tab 时再次自愈（issue #6）
     ├── orchestrate.ts      create → 占位 rename → selectModel(默认 flash/关思考) → prompt + 继续追问 + 回答后重命名
+    ├── ConfigPanel.tsx       功能配置面板（设置齿轮弹窗：编辑 sidebarqa 命名空间，回答模型/渠道下拉 + 摘要文本行）
+    ├── config-fields.ts      配置面板行声明 + 数字钳制 + catalog 选项解析（纯函数，可测）
     ├── store.ts            父→子 映射（localStorage 持久化，支持嵌套）+ 待提问引文 + 已命名标记
     ├── injection.ts        XML 转义/消毒 + 注入格式 + 占位主题生成
     ├── answer.ts           历史流 → 回答文本折叠

--- a/README_EN.md
+++ b/README_EN.md
@@ -58,18 +58,18 @@ Restart `dsh web` (host-half changes need a restart; client-half changes only ne
 
 ## Configuration
 
-Configuration lives in the DSH settings service under the `sidebarqa` namespace (settings.yaml or the settings page). **Web entry point**: DSH Settings → Side Cards → the gear 「功能配置」 popup on the 「追问」 card (provided by dsh-better-sidebar v0.12+ `settings.render`), editing the fields below — text rows commit on blur/Enter, number rows clamp to their range, writes go through `/sidebarqa/api/config.update` with a revision optimistic lock (conflicts prompt a retry).
+Configuration lives in the DSH settings service under the `sidebarqa` namespace (settings.yaml or the settings page). **Web entry point**: DSH Settings → Side Cards → the gear 「功能配置」 popup on the 「追问」 card (provided by dsh-better-sidebar v0.12+ `settings.render`), editing the fields below — text rows commit on blur/Enter, number rows clamp to their range, writes go through `/sidebarqa/api/config.update` with a revision optimistic lock (conflicts prompt a retry). **The answer and summary channel/model rows are all dropdowns** populated from the live model catalog (host `ctx.llm.listProviders()` + `listModels()`, served through `/sidebarqa/api/catalog`): the channel lists hold only the providers the deployment has **configured/enabled (with a registered adapter)** — matching what DSH itself is using, dormant unconfigured channels are omitted (the summary channel adds an "inherit the asked session" empty option), and the model list follows the chosen channel (switching channel re-anchors the model to that channel's first model, or keeps the previous model when that channel still serves it; the summary model under "inherit" shows the union of every channel's models). A saved value the catalog has not caught up with stays in the options so a stored route never renders blank.
 
 | Key | Default | Description |
 |---|---|---|
-| `summarizeProvider` | `''` | Summary fast-model channel; empty = inherit the asked session's provider |
-| `summarizeModel` | `deepseek-v4-flash` | Summary fast no-thinking model |
+| `summarizeProvider` | `''` | Summary fast-model channel; empty = inherit the asked session's provider (dropdown, includes "inherit") |
+| `summarizeModel` | `deepseek-v4-flash` | Summary fast no-thinking model (dropdown, follows the chosen channel) |
 | `summarizeReasoningEffort` | `off` | Summary reasoning effort (`off`/`high`/`max` dropdown) |
 | `summarizeBudgetTokens` | `160` | Background-summary output budget (tokens) |
 | `recentWindowMessages` | `2` | **Verbatim** recent messages kept (the current-state anchor, not model-compressed) |
 | `backgroundWindowMessages` | `12` | Max older messages handed to the model for compression |
-| `answerProvider` | `deepseek-official` | Follow-up answer model channel |
-| `answerModel` | `deepseek-v4-flash` | Follow-up answer model |
+| `answerProvider` | `deepseek-official` | Follow-up answer model channel (dropdown from the live catalog) |
+| `answerModel` | `deepseek-v4-flash` | Follow-up answer model (dropdown that follows the chosen channel) |
 | `answerReasoningEffort` | `off` | Follow-up reasoning effort (`off`/`high`/`max` dropdown) |
 | `titleBudgetTokens` | `64` | Output budget for the post-answer retitle (tokens) |
 
@@ -95,6 +95,8 @@ dsh-sidebar-qa (bundle: dsh.bundle + package.json#dsh.client)
     ├── ensure-panel.ts     collapsed-panel self-heal: expansion decision + expand via SidebarStore (pure, tested)
     ├── tab-activation.ts   onActivate bridge: re-heal when a tab is re-activated after a manual collapse (issue #6)
     ├── orchestrate.ts      create → placeholder rename → selectModel (default flash / thinking off) → prompt + continue + post-answer retitle
+    ├── ConfigPanel.tsx     config gear popup (edits the sidebarqa namespace; answer channel/model dropdowns)
+    ├── config-fields.ts    config row declarations + number coercion + catalog option resolution (pure, tested)
     ├── store.ts            parent→child map (localStorage-persisted, nested) + pending quotes + titled marks
     ├── injection.ts        XML escape/sanitize + injection format + placeholder topic
     ├── answer.ts           history stream → answer text folding

--- a/src/client/ConfigPanel.tsx
+++ b/src/client/ConfigPanel.tsx
@@ -13,7 +13,16 @@
  */
 import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { sidebarqaApi, type SidebarqaConfigView } from './api.ts'
-import { CONFIG_FIELDS, coerceNumberField, type ConfigField } from './config-fields.ts'
+import type { SidebarqaCatalog } from '../context-types.ts'
+import {
+  CATALOG_INHERIT_VALUE,
+  CONFIG_FIELDS,
+  coerceNumberField,
+  modelOptionsOf,
+  providerOptionsOf,
+  type ConfigField,
+  type ConfigFieldOption,
+} from './config-fields.ts'
 import css from './config-panel.module.css'
 
 /** Map one wire failure to an inline message (the conflict gets friendly copy). */
@@ -28,11 +37,13 @@ function messageOf(error: unknown): string {
 function FieldRow(props: {
   field: ConfigField
   value: string
+  options?: readonly ConfigFieldOption[]
   onCommit: (raw: string) => string
 }): ReactElement {
-  const { field, value, onCommit } = props
+  const { field, value, options, onCommit } = props
   const [draft, setDraft] = useState(value)
   const number = field.type === 'number'
+  const select = field.type === 'select' || field.type === 'catalog'
   const commit = (raw: string): void => { setDraft(onCommit(raw)) }
   return (
     <div className={css.row}>
@@ -40,14 +51,14 @@ function FieldRow(props: {
         <span className={css.title}>{field.label}</span>
         {field.desc !== undefined && field.desc !== '' && <span className={css.desc}>{field.desc}</span>}
       </span>
-      {field.type === 'select' ? (
+      {select ? (
         <select
           className={css.select}
           value={draft}
           aria-label={field.label}
           onChange={(event) => { commit(event.currentTarget.value) }}
         >
-          {field.options?.map((option) => (
+          {options?.map((option) => (
             <option key={option.value} value={option.value}>{option.label}</option>
           ))}
         </select>
@@ -78,6 +89,7 @@ function FieldRow(props: {
  */
 export function ConfigPanel(): ReactElement {
   const [config, setConfig] = useState<SidebarqaConfigView | null>(null)
+  const [catalog, setCatalog] = useState<SidebarqaCatalog | null>(null)
   const [error, setError] = useState<string | null>(null)
   // The LATEST optimistic config: nested updates build from this ref, not the
   // render-time `config`, so two same-tick commits never drop each other.
@@ -102,6 +114,9 @@ export function ConfigPanel(): ReactElement {
       if (dirtyRef.current) return
       update(view.value ?? null)
     }).catch(() => { /* keep the loading state; the store defaults stay unreachable from a broken wire */ })
+    // The catalog is advisory (never persisted here): a failure just leaves
+    // the answer provider/model rows as empty selects, not a broken panel.
+    void sidebarqaApi.catalog().then((next) => { if (!cancelled) setCatalog(next) }).catch(() => {})
     return () => { cancelled = true }
   }, [])
 
@@ -137,12 +152,66 @@ export function ConfigPanel(): ReactElement {
       commit({ [field.key]: clamped })
       return String(clamped)
     }
+    if (field.type === 'catalog' && field.source === 'answerProvider') {
+      // The answer channel changed: re-anchor the model to the new channel's
+      // first model (or the previous model when the new channel still serves
+      // it), so a channel switch never leaves a stale model routed elsewhere.
+      const providers = catalog?.providers ?? []
+      const chosen = providers.find(provider => provider.provider === raw)
+      const previousModel = String(current?.answerModel ?? '')
+      const stillServed = chosen?.models.some(model => model.id === previousModel) ?? false
+      const nextModel = stillServed || chosen === undefined
+        ? previousModel
+        : chosen.models[0]?.id ?? previousModel
+      commit({ answerProvider: raw, ...(nextModel === previousModel ? {} : { answerModel: nextModel }) })
+      return raw
+    }
+    if (field.type === 'catalog' && field.source === 'summarizeProvider') {
+      // The summary channel changed: re-anchor the summary model. Switching to
+      // "inherit" (empty) keeps the current model (it is always used on the
+      // inherited channel); a concrete channel re-anchors like the answer row.
+      const providers = catalog?.providers ?? []
+      const previousModel = String(current?.summarizeModel ?? '')
+      if (raw === CATALOG_INHERIT_VALUE) {
+        commit({ summarizeProvider: raw })
+        return raw
+      }
+      const chosen = providers.find(provider => provider.provider === raw)
+      const stillServed = chosen?.models.some(model => model.id === previousModel) ?? false
+      const nextModel = stillServed || chosen === undefined
+        ? previousModel
+        : chosen.models[0]?.id ?? previousModel
+      commit({ summarizeProvider: raw, ...(nextModel === previousModel ? {} : { summarizeModel: nextModel }) })
+      return raw
+    }
     commit({ [field.key]: raw })
     return raw
   }
 
   if (config === null) {
     return <div className={css.loading}>加载配置…</div>
+  }
+  const currentConfig = config
+
+  // Resolve each row's render options: catalog rows draw from the live model
+  // catalog (model rows are scoped by their channel's currently chosen value).
+  // A stored value that the catalog has not caught up with stays listed so the
+  // select never renders blank for a saved route.
+  const optionsOf = (field: ConfigField): readonly ConfigFieldOption[] | undefined => {
+    if (field.type !== 'catalog') return field.options
+    const providers = catalog?.providers ?? []
+    const stored = String(currentConfig[field.key] ?? '')
+    const scoping = field.source === 'answerModel'
+      ? currentConfig.answerProvider
+      : field.source === 'summarizeModel'
+        ? currentConfig.summarizeProvider
+        : null
+    const base = scoping === null
+      ? providerOptionsOf(providers, field.source ?? '')
+      : modelOptionsOf(providers, scoping)
+    return stored !== '' && !base.some(option => option.value === stored)
+      ? [...base, { value: stored, label: stored }]
+      : base
   }
 
   return (
@@ -153,9 +222,10 @@ export function ConfigPanel(): ReactElement {
             // Keyed by the committed value: a failed commit reverts config, the
             // key changes, and the row remounts with the stored value (typing
             // never changes the key, so mid-edit drafts survive re-renders).
-            key={`${field.key}:${String(config[field.key] ?? '')}`}
+            key={`${field.key}:${String(currentConfig[field.key] ?? '')}`}
             field={field}
-            value={String(config[field.key] ?? '')}
+            value={String(currentConfig[field.key] ?? '')}
+            options={optionsOf(field)}
             onCommit={(raw) => onCommit(field, raw)}
           />
         ))}

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -5,6 +5,7 @@
  */
 import type { Context } from '../context-types.ts'
 import type { SidebarqaHistoryStrategy } from '../config.ts'
+import type { SidebarqaCatalog } from '../context-types.ts'
 
 /** One wire failure. */
 export class SidebarqaApiError extends Error {
@@ -85,6 +86,8 @@ export const sidebarqaApi = {
     call<TitleResult>('title', payload, signal),
   config: (signal?: AbortSignal) =>
     call<SidebarqaConfigView>('config', {}, signal),
+  catalog: (signal?: AbortSignal) =>
+    call<SidebarqaCatalog>('catalog', {}, signal),
   configGet: (signal?: AbortSignal) =>
     call<SidebarqaConfigEnvelope>('config.get', {}, signal),
   configUpdate: (patch: Record<string, unknown>, expectedRevision?: number) =>

--- a/src/client/config-fields.ts
+++ b/src/client/config-fields.ts
@@ -5,12 +5,13 @@
  * the number coercion, so it stays free of React and the fetch layer.
  */
 import type { SidebarqaConfigView } from './api.ts'
+import type { SidebarqaLlmModel, SidebarqaCatalogProvider } from '../context-types.ts'
 
 /** One editable config key. */
 export type ConfigFieldKey = keyof SidebarqaConfigView
 
 /** One config panel row control type. */
-export type ConfigFieldType = 'text' | 'number' | 'select'
+export type ConfigFieldType = 'text' | 'number' | 'select' | 'catalog'
 
 /** One choice of a select row. */
 export interface ConfigFieldOption {
@@ -18,7 +19,17 @@ export interface ConfigFieldOption {
   label: string
 }
 
-/** One config panel row: a text field, a clamped number field, or a select. */
+/** What a `catalog` row draws its options from. */
+export type CatalogFieldSource = 'answerProvider' | 'answerModel' | 'summarizeProvider' | 'summarizeModel'
+
+/** The inherit sentinel stored for the summarize channel: '' (follow the asked session). */
+export const CATALOG_INHERIT_VALUE = ''
+
+/** Label of the summarize channel's "inherit the asked session" option. */
+export const CATALOG_INHERIT_LABEL = '继承被追问会话'
+
+/** One config panel row: a text field, a clamped number field, a select, or a
+ *  provider/model dropdown sourced from the live model catalog. */
 export interface ConfigField {
   key: ConfigFieldKey
   label: string
@@ -32,6 +43,12 @@ export interface ConfigField {
   desc?: string
   /** Choices for select fields. */
   options?: readonly ConfigFieldOption[]
+  /**
+   * For `type: 'catalog'` rows, the role this row plays. A provider row names
+   * the provider it lists; a model row names the provider whose `…Model`
+   * options it is scoped by.
+   */
+  source?: CatalogFieldSource
 }
 
 /** DSH reasoning-effort vocabulary (mirror of the host `off | high | max`). */
@@ -58,11 +75,11 @@ export const HISTORY_STRATEGY_OPTIONS: readonly ConfigFieldOption[] = [
 export const CONFIG_FIELDS: readonly ConfigField[] = [
   { key: 'historyStrategy', label: '上下文策略', type: 'select', options: HISTORY_STRATEGY_OPTIONS, desc: '追问如何继承主对话上下文：全量（fork+缓存命中）/ 压缩 / 机械裁切' },
   { key: 'trimWindowMessages', label: '裁切保留条数', type: 'number', min: 1, max: 256, desc: '机械裁切模式保留的最近消息条数（1–256）' },
-  { key: 'answerProvider', label: '回答模型渠道', type: 'text', desc: '子对话回答模型的 provider' },
-  { key: 'answerModel', label: '回答模型', type: 'text', desc: '子对话回答模型的 id' },
+  { key: 'answerProvider', label: '回答模型渠道', type: 'catalog', source: 'answerProvider', desc: '子对话回答模型的 provider（从已配置渠道中选择）' },
+  { key: 'answerModel', label: '回答模型', type: 'catalog', source: 'answerProvider', desc: '子对话回答模型的 id（随所选渠道切换）' },
   { key: 'answerReasoningEffort', label: '回答思考模式', type: 'select', options: REASONING_EFFORT_OPTIONS, desc: 'Off 关闭思考；High / Max 逐级增强推理' },
-  { key: 'summarizeProvider', label: '摘要模型渠道', type: 'text', placeholder: '留空 = 继承被追问会话', desc: '快速无思考摘要/标题模型的 provider' },
-  { key: 'summarizeModel', label: '摘要模型', type: 'text', desc: '快速无思考模型的 id' },
+  { key: 'summarizeProvider', label: '摘要模型渠道', type: 'catalog', source: 'summarizeProvider', desc: '快速无思考摘要/标题模型的 provider（空 = 继承被追问会话）' },
+  { key: 'summarizeModel', label: '摘要模型', type: 'catalog', source: 'summarizeProvider', desc: '快速无思考模型的 id（随所选渠道切换）' },
   { key: 'summarizeReasoningEffort', label: '摘要思考模式', type: 'select', options: REASONING_EFFORT_OPTIONS, desc: 'Off 关闭思考；High / Max 逐级增强推理' },
 ]
 
@@ -79,4 +96,50 @@ export function coerceNumberField(raw: string, min?: number, max?: number): numb
   if (min !== undefined && clamped < min) clamped = min
   if (max !== undefined && clamped > max) clamped = max
   return clamped
+}
+
+/**
+ * The provider catalog row's choices, in provider order. The summarize channel
+ * prepends its "inherit the asked session" sentinel (empty value) so the
+ * default `''` stays selectable from the dropdown.
+ * @param catalog - the live model catalog.
+ * @param source - the row's role; only `summarizeProvider` gets the inherit entry.
+ */
+export function providerOptionsOf(
+  catalog: readonly SidebarqaCatalogProvider[],
+  source: string,
+): ConfigFieldOption[] {
+  const rows = catalog.map(provider => ({ value: provider.provider, label: provider.displayName }))
+  if (source === 'summarizeProvider') {
+    return [{ value: CATALOG_INHERIT_VALUE, label: CATALOG_INHERIT_LABEL }, ...rows]
+  }
+  return rows
+}
+
+/**
+ * The model catalog row's choices for one provider route: that provider's
+ * catalog models, or [] while the provider is unknown/unchosen.
+ */
+export function modelOptionsOf(
+  catalog: readonly SidebarqaCatalogProvider[],
+  provider: string,
+): ConfigFieldOption[] {
+  if (provider !== '') {
+    const match = catalog.find(candidate => candidate.provider === provider)
+    if (match === undefined) return []
+    return match.models.map((model: SidebarqaLlmModel) => ({ value: model.id, label: model.name }))
+  }
+  // Empty provider = the sentence "inherit the asked session's channel": the
+  // model id is picked from ANY configured channel, so offer the union of all
+  // catalog models (deduplicated by id, first channel wins the label).
+  const seen = new Set<string>()
+  const rows: ConfigFieldOption[] = []
+  for (const group of catalog) {
+    for (const model of group.models) {
+      if (seen.has(model.id)) continue
+      seen.add(model.id)
+      rows.push({ value: model.id, label: model.name })
+    }
+  }
+  return rows
 }

--- a/src/context-types.ts
+++ b/src/context-types.ts
@@ -88,9 +88,41 @@ export type SidebarqaStreamChunk =
   | { type: 'usage'; usage: unknown }
   | { type: 'finish'; reason: { kind?: string } }
 
-/** The llm service face this plugin uses (stream a one-shot summary call). */
+/** One provider route of the served catalog (structural mirror of LlmProviderInfo). */
+export interface SidebarqaLlmProvider {
+  /** Provider route key used by {@link SidebarqaLlmRequest.provider}. */
+  id: string
+  /** Human-readable provider name for selectors. */
+  name: string
+}
+
+/** One model row of the served catalog (structural mirror of LlmModelInfo). */
+export interface SidebarqaLlmModel {
+  /** Model id passed to Generate requests. */
+  id: string
+  /** Human-readable model name for selectors. */
+  name: string
+}
+
+/** One provider group of the served ad-hoc catalog (provider + its models). */
+export interface SidebarqaCatalogProvider {
+  provider: string
+  displayName: string
+  models: readonly SidebarqaLlmModel[]
+}
+
+/** The ad-hoc model catalog: every configurable provider with its models. */
+export interface SidebarqaCatalog {
+  providers: readonly SidebarqaCatalogProvider[]
+}
+
+/** The llm service face this plugin uses (stream a one-shot summary call + catalog lookup). */
 export interface SidebarqaLlmService {
   stream(options: SidebarqaLlmRequest): AsyncIterable<SidebarqaStreamChunk>
+  /** Every provider route with a registered adapter (only the channels that are configured/enabled). */
+  listProviders(): readonly SidebarqaLlmProvider[]
+  /** The models a provider route can serve ([] for an unregistered route). */
+  listModels(provider: string): Promise<readonly SidebarqaLlmModel[]>
 }
 
 /** One loader entry's options slice (the connection row's resolved config). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,13 @@ import {
   TITLE_MAX_BYTES,
   TITLE_SYSTEM,
 } from './title.ts'
-import type { SidebarqaLlmMessage, SidebarqaSettingsScope, SidebarqaSettingsService } from './context-types.ts'
+import type {
+  SidebarqaCatalog,
+  SidebarqaLlmMessage,
+  SidebarqaLlmModel,
+  SidebarqaSettingsScope,
+  SidebarqaSettingsService,
+} from './context-types.ts'
 
 export { SIDEBARQA_DEFAULTS, SIDEBARQA_SETTINGS_NS } from './config.ts'
 export type { SidebarqaConfig, SidebarqaHistoryStrategy, SidebarqaReasoningEffort } from './config.ts'
@@ -141,6 +147,19 @@ function buildApi(
 ): Record<string, ApiMethod> {
   return {
     config: (): SidebarqaConfig => getConfig(),
+    catalog: async (): Promise<SidebarqaCatalog> => {
+      const providers = ctx.llm.listProviders().map(async (provider) => {
+        let models: readonly SidebarqaLlmModel[] = []
+        try {
+          models = await ctx.llm.listModels(provider.id)
+        } catch {
+          // A route that cannot enumerate its models still shows up (empty
+          // model list) so the user can name the provider before its models load.
+        }
+        return { provider: provider.id, displayName: provider.name, models }
+      })
+      return { providers: await Promise.all(providers) }
+    },
     'config.get': (): { value?: unknown; revision?: number } => {
       const face = getConfigFace()
       return face?.get() ?? { value: getConfig(), revision: undefined }

--- a/tests/config-fields.spec.ts
+++ b/tests/config-fields.spec.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it } from 'vitest'
 import {
+  CATALOG_INHERIT_VALUE,
   CONFIG_FIELDS,
   HISTORY_STRATEGY_OPTIONS,
+  modelOptionsOf,
+  providerOptionsOf,
   REASONING_EFFORT_OPTIONS,
   coerceNumberField,
 } from '../src/client/config-fields.ts'
+import type { SidebarqaCatalog } from '../src/context-types.ts'
+
+const CATALOG: SidebarqaCatalog = {
+  providers: [
+    {
+      provider: 'deepseek-official',
+      displayName: 'DeepSeek',
+      models: [
+        { id: 'deepseek-v4-flash', name: 'DeepSeek-V4-Flash' },
+        { id: 'deepseek-v4-pro', name: 'DeepSeek-V4-Pro' },
+      ],
+    },
+    { provider: 'openai', displayName: 'OpenAI', models: [{ id: 'gpt-5', name: 'GPT-5' }] },
+  ],
+}
 
 describe('coerceNumberField', () => {
   it('parses and clamps to the declared range', () => {
@@ -74,6 +92,80 @@ describe('CONFIG_FIELDS', () => {
     expect(field?.type).toBe('number')
     expect(field?.min).toBe(1)
     expect(field?.max).toBe(256)
+  })
+
+  it('declares the answer/summarize provider + model as catalog rows', () => {
+    const answerProvider = CONFIG_FIELDS.find(candidate => candidate.key === 'answerProvider')
+    const answerModel = CONFIG_FIELDS.find(candidate => candidate.key === 'answerModel')
+    const summarizeProvider = CONFIG_FIELDS.find(candidate => candidate.key === 'summarizeProvider')
+    const summarizeModel = CONFIG_FIELDS.find(candidate => candidate.key === 'summarizeModel')
+    expect(answerProvider?.type).toBe('catalog')
+    expect(answerProvider?.source).toBe('answerProvider')
+    expect(answerModel?.type).toBe('catalog')
+    expect(answerModel?.source).toBe('answerProvider')
+    expect(summarizeProvider?.type).toBe('catalog')
+    expect(summarizeProvider?.source).toBe('summarizeProvider')
+    expect(summarizeModel?.type).toBe('catalog')
+    expect(summarizeModel?.source).toBe('summarizeProvider')
+  })
+})
+
+describe('providerOptionsOf', () => {
+  it('maps catalog providers to select options in catalog order', () => {
+    expect(providerOptionsOf(CATALOG.providers, 'answerProvider')).toEqual([
+      { value: 'deepseek-official', label: 'DeepSeek' },
+      { value: 'openai', label: 'OpenAI' },
+    ])
+  })
+
+  it('prepends the inherit sentinel for the summarize channel', () => {
+    expect(providerOptionsOf(CATALOG.providers, 'summarizeProvider')).toEqual([
+      { value: CATALOG_INHERIT_VALUE, label: '继承被追问会话' },
+      { value: 'deepseek-official', label: 'DeepSeek' },
+      { value: 'openai', label: 'OpenAI' },
+    ])
+  })
+
+  it('yields only the inherit entry for an empty catalog', () => {
+    expect(providerOptionsOf([], 'summarizeProvider')).toEqual([
+      { value: CATALOG_INHERIT_VALUE, label: '继承被追问会话' },
+    ])
+    expect(providerOptionsOf([], 'answerProvider')).toEqual([])
+  })
+})
+
+describe('modelOptionsOf', () => {
+  it('maps a chosen provider-s models to select options', () => {
+    expect(modelOptionsOf(CATALOG.providers, 'deepseek-official')).toEqual([
+      { value: 'deepseek-v4-flash', label: 'DeepSeek-V4-Flash' },
+      { value: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro' },
+    ])
+  })
+
+  it('yields [] for an unknown provider', () => {
+    expect(modelOptionsOf(CATALOG.providers, 'nope')).toEqual([])
+  })
+
+  it('flattens the whole catalog when the channel is inherit (empty)', () => {
+    expect(modelOptionsOf(CATALOG.providers, CATALOG_INHERIT_VALUE)).toEqual([
+      { value: 'deepseek-v4-flash', label: 'DeepSeek-V4-Flash' },
+      { value: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro' },
+      { value: 'gpt-5', label: 'GPT-5' },
+    ])
+  })
+
+  it('deduplicates model ids by id across providers', () => {
+    const dupCatalog: SidebarqaCatalog = {
+      providers: [
+        ...CATALOG.providers,
+        { provider: 'gateway', displayName: 'Gateway', models: [{ id: 'deepseek-v4-flash', name: 'Proxy Flash' }] },
+      ],
+    }
+    expect(modelOptionsOf(dupCatalog.providers, CATALOG_INHERIT_VALUE)).toEqual([
+      { value: 'deepseek-v4-flash', label: 'DeepSeek-V4-Flash' },
+      { value: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro' },
+      { value: 'gpt-5', label: 'GPT-5' },
+    ])
   })
 })
 


### PR DESCRIPTION
把「功能配置」面板的「回答模型渠道 / 回答模型 / 摘要模型渠道 / 摘要模型」四行从自由文本输入改为下拉框，选项来自 DSH 运行时模型目录。

## 改动
- Host 新增 `/sidebarqa/api/catalog` 路由：经 `ctx.llm.listProviders()` + `listModels()` 枚举 provider 及其模型。
- 渠道下拉只列出当前部署**已配置/已启用（有已注册 adapter）**的 channel —— 与 DSH 本身正在用的一致，未配置的 dormant 渠道不出现。
- 摘要渠道额外提供「继承被追问会话」空值项（对应原默认 `''`）。
- 模型下拉随所选渠道联动：切换渠道自动锚定新渠道首个模型，原模型仍被该渠道服务则保留；摘要模型在「继承」态展示全部渠道模型的去重并集。
- 已保存但不在目录中的值仍保留在选项中，避免已存路由显示为空。
- 新增单测覆盖 provider/model 选项解析与并集去重；更新 README / README_EN / CHANGELOG。

## 验证
`pnpm typecheck`、`pnpm test`（179 通过）、`pnpm build` 全绿。

## 部署提醒
host + client 半均有改动，需重启 `dsh web` 并硬刷新浏览器。